### PR TITLE
Unblock spclient.wg.spotify.com

### DIFF
--- a/data/app/music.txt
+++ b/data/app/music.txt
@@ -46,7 +46,6 @@
 127.0.0.1 adeventtracker.spotify.com
 127.0.0.1 analytics.spotify.com
 127.0.0.1 log.spotify.com
-127.0.0.1 spclient.wg.spotify.com
 127.0.0.1 weblb-wg.gslb.spotify.com
 #http://www.miguvideo.com/
 127.0.0.1 adxserver.ad.cmvideo.cn

--- a/hosts
+++ b/hosts
@@ -1729,7 +1729,6 @@
 127.0.0.1 adeventtracker.spotify.com
 127.0.0.1 analytics.spotify.com
 127.0.0.1 log.spotify.com
-127.0.0.1 spclient.wg.spotify.com
 127.0.0.1 weblb-wg.gslb.spotify.com
 127.0.0.1 adxserver.ad.cmvideo.cn
 127.0.0.1 dspserver.ad.cmvideo.cn

--- a/hosts.txt
+++ b/hosts.txt
@@ -2185,7 +2185,6 @@
 127.0.0.1 adeventtracker.spotify.com
 127.0.0.1 analytics.spotify.com
 127.0.0.1 log.spotify.com
-127.0.0.1 spclient.wg.spotify.com
 127.0.0.1 weblb-wg.gslb.spotify.com
 #http://www.miguvideo.com/
 127.0.0.1 adxserver.ad.cmvideo.cn


### PR DESCRIPTION
An offline warning occurs when we click the search result in Spotify app (test on Android), if spclient.wg.spotify.com is blocked.